### PR TITLE
add default android studio sdk folder name in android

### DIFF
--- a/MauiCheck/AndroidSdk/AndroidSdkManager.cs
+++ b/MauiCheck/AndroidSdk/AndroidSdkManager.cs
@@ -14,6 +14,9 @@ namespace DotNetCheck.AndroidSdk
 				new string[] {
 					Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Android", "android-sdk"),
 					Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "Android", "android-sdk"),
+					Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Android", "sdk"),
+					Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "Android", "sdk"),
+					Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "AppData", "Local", "Android", "sdk"),
 				} :
 				new string []
 				{


### PR DESCRIPTION
when you install android studio , it install sdk on C:\Users\YourUserNameOnWindows\AppData\Local\Android\sdk by default and some people install it on ProgramFiles(X86)\android\sdk and it just for decrease duplication