### PR TITLE
Add check for Edge WebView2 on Windows

### DIFF
--- a/MauiCheck/Checkups/EdgeWebView2Checkup.cs
+++ b/MauiCheck/Checkups/EdgeWebView2Checkup.cs
@@ -1,0 +1,43 @@
+﻿using System.Threading.Tasks;
+using DotNetCheck.Models;
+
+namespace DotNetCheck.Checkups
+{
+    public class EdgeWebView2Checkup : Checkup
+	{
+		public override bool IsPlatformSupported(Platform platform)
+			=> platform == Platform.Windows;
+
+		public override string Id => "edgewebview2";
+
+		public override string Title => $"Edge WebView2";
+		
+		public override bool ShouldExamine(SharedState history)
+			=> Manifest?.Check?.VSWin != null;
+
+		public override Task<DiagnosticResult> Examine(SharedState history)
+		{
+			// Info here: https://docs.microsoft.com/en-us/microsoft-edge/webview2/concepts/distribution#online-only-deployment
+			string WebView2RegistryKey = @"HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\EdgeUpdate\Clients\{F3017226-FE2A-4295-8BDF-00C3A9A7E4C5}";
+
+			var webView2VersionObject = Microsoft.Win32.Registry.GetValue(
+                keyName: WebView2RegistryKey,
+                valueName: "pv",
+                defaultValue: null);
+
+			var webView2Version = webView2VersionObject as string;
+
+			var isWebView2Installed = !string.IsNullOrEmpty(webView2Version);
+			if (isWebView2Installed)
+            {
+				ReportStatus($"Found Edge WebView2 version {webView2Version}", Status.Ok);
+                return Task.FromResult(DiagnosticResult.Ok(this));
+            }
+
+			return Task.FromResult(new DiagnosticResult(
+                Status.Error,
+                this,
+                new Suggestion($"Download Edge WebView2 from https://developer.microsoft.com/microsoft-edge/webview2/")));
+		}
+	}
+}

--- a/MauiCheck/MauiCheck.csproj
+++ b/MauiCheck/MauiCheck.csproj
@@ -27,6 +27,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
     <PackageReference Include="NuGet.Packaging" Version="5.9.0" />
     <PackageReference Include="NuGet.Protocol" Version="5.9.0" />
     <PackageReference Include="NuGet.Versioning" Version="5.9.0" />

--- a/MauiCheck/Program.cs
+++ b/MauiCheck/Program.cs
@@ -28,7 +28,8 @@ namespace DotNetCheck
 				new AndroidSdkPackagesCheckup(),
 				new XCodeCheckup(),
 				new DotNetCheckup(),
-				new DotNetWorkloadDuplicatesCheckup());
+				new DotNetWorkloadDuplicatesCheckup(),
+				new EdgeWebView2Checkup());
 
 			CheckupManager.RegisterCheckupContributors(
 				new DotNetSdkCheckupContributor());


### PR DESCRIPTION
Fixes #66

As a starting point, this just checks if WebView2 is installed, and tells you where to download it.

It might be nice to also later add an option to download and install it for the user (but of course that's a bit more work).