### PR TITLE
[main] microsoft-android-sdk-full is now android-aot

### DIFF
--- a/manifests/maui-main.manifest.json
+++ b/manifests/maui-main.manifest.json
@@ -107,7 +107,7 @@
           ],
           "workloads": [
             {
-                "workloadId": "microsoft-android-sdk-full",
+                "workloadId": "android-aot",
                 "packageId": "Microsoft.NET.Sdk.Android.Manifest-6.0.100",
                 "version": "$(ANDROID_SDK_VERSION)"
             },


### PR DESCRIPTION
You could also use the `android` workload, if you don't need to install AOT support.