### PR TITLE
chore: update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ maui-check
 
 If you run into problems with maui-check, you should generally try the following:
 
-1. Update the tool to the latest version: `dotnet tool update -g redth.net.maui.check --source https://api.nuget.org/v3/index.json`
+1. Update the tool to the latest version: `dotnet tool update -g redth.net.maui.check --add-source https://api.nuget.org/v3/index.json`
 2. Run with `maui-check --force-dotnet` to ensure the workload repair/update/install commands run regardless of if maui-check thinks the workload versions look good
 3. If you have errors still, it may help to run the [Clean-Old-DotNet6-Previews.ps1](https://github.com/Redth/dotnet-maui-check/blob/main/Clean-Old-DotNet6-Previews.ps1) script to remove old SDK Packs, templates, or otherwise old cached preview files that might be causing the problem.  Try running `maui-check --force-dotnet` again after this step.
 4. Finally, if you have problems, run with `--verbose` flag and capture the output and add it to a new issue.


### PR DESCRIPTION
The correct CLI argument is `--add-source` - using `--source` is not a valid config option
https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-tool-install
and results in an error:

```
$ dotnet tool update -g redth.net.maui.check --source https://api.nuget.o rg/v3/index.json
Unrecognized command or argument '--source'
Unrecognized command or argument 'https://api.nuget.org/v3/index.json'
```