### PR TITLE
Switched from exact to minimum

### DIFF
--- a/manifests/maui-main.manifest.json
+++ b/manifests/maui-main.manifest.json
@@ -63,8 +63,8 @@
       }
     },
     "xcode": {
-      "exactVersion": "19466",
-      "exactVersionName": "13.1"
+      "minimumVersion": "19466",
+      "minimumVersionName": "13.1"
     },
     "vswin": {
       "minimumVersion": "17.1.0-pre.1.0"

--- a/manifests/maui-preview.manifest.json
+++ b/manifests/maui-preview.manifest.json
@@ -63,8 +63,8 @@
       }
     },
     "xcode": {
-      "exactVersion": "19466",
-      "exactVersionName": "13.1"
+      "minimumVersion": "19466",
+      "minimumVersionName": "13.1"
     },
     "vswin": {
       "minimumVersion": "17.1.0-pre.1.0"

--- a/manifests/maui.manifest.json
+++ b/manifests/maui.manifest.json
@@ -22,8 +22,8 @@
       }
     },
     "xcode": {
-      "exactVersion": "19466",
-      "exactVersionName": "13.1"
+      "minimumVersion": "19466",
+      "minimumVersionName": "13.1"
     },
     "vswin": {
       "minimumVersion": "17.1-pre.1.0"


### PR DESCRIPTION
Since 13.2.1 is the latest version we don't want people to see the error
<img width="299" alt="image" src="https://user-images.githubusercontent.com/25557206/147703377-300f6ef4-b8a3-4840-beef-1c6b8292b8de.png">
