### PR TITLE
Roll forward to allow running with newer dotnet versions

### DIFF
--- a/MauiCheck/MauiCheck.csproj
+++ b/MauiCheck/MauiCheck.csproj
@@ -9,6 +9,7 @@
     <ApplicationManifest>app.manifest</ApplicationManifest>
     <PackAsToolShimRuntimeIdentifiers>win-x64;win-x86;osx-x64</PackAsToolShimRuntimeIdentifiers>
     <LangVersion>latest</LangVersion>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Fixes #162 